### PR TITLE
Import Re instead of regex

### DIFF
--- a/classify_xvsy_logreg.py
+++ b/classify_xvsy_logreg.py
@@ -14,7 +14,7 @@ Options:
     -k --keep-last        Quit immediately if results file found
 
 """
-import regex as re
+import re
 import sys
 import os
 import json


### PR DESCRIPTION
Build wheel for Regex fails on macOS because it has C-bindings that won't build unless you have python3-dev. Unfortunately, Python3 on my machine did not ship with python3-dev, and my reading suggests that it did not for anybody. Please verify that.