### PR TITLE
Replace regex with re

### DIFF
--- a/classify_xvsy_logreg.py
+++ b/classify_xvsy_logreg.py
@@ -14,7 +14,7 @@ Options:
     -k --keep-last        Quit immediately if results file found
 
 """
-import regex as re
+import re
 import sys
 import os
 import json


### PR DESCRIPTION
Build wheel for Regex fails on macOS because it has C-bindings that won't build unless you have python3-dev. Unfortunately, Python3 on my machine does not ship with python3-dev. My reading suggests that it does not for any machine. Verify that and merge accordingly!